### PR TITLE
Set tb vehicle.id to autogenuuid

### DIFF
--- a/doc/schema/vehicle.puml
+++ b/doc/schema/vehicle.puml
@@ -30,7 +30,7 @@ entity "<b>$name</b>" as $slug << (V, Aquamarine) >>
 <color:#Green><&key></color> $name
 !endprocedure
 
-title "OAuth2"
+title "Vehicle"
 
 $table("vehicle_type", "t_vehicle_type") {
     $primary_key("id") : SERIAL

--- a/vehicle-service/src/main/resources/db.changelog/ddl.tables/vehicle.sql
+++ b/vehicle-service/src/main/resources/db.changelog/ddl.tables/vehicle.sql
@@ -2,8 +2,9 @@
 
 --changeset application:1
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 CREATE TABLE IF NOT EXISTS vehicle (
-    id UUID PRIMARY KEY,
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     model_id INTEGER NOT NULL,
     image_uri VARCHAR,
     rent_price BIGINT NOT NULL DEFAULT 0,

--- a/vehicle-service/src/main/resources/db.changelog/dml/dummy_vehicle_data.sql
+++ b/vehicle-service/src/main/resources/db.changelog/dml/dummy_vehicle_data.sql
@@ -19,7 +19,7 @@ INSERT INTO vehicle_model(id, type_id, brand_id, name) VALUES
 SELECT SETVAL(pg_get_serial_sequence('vehicle_model', 'id'), (SELECT MAX(id) FROM vehicle_model));
 
 INSERT INTO vehicle(id, model_id, rent_price, name, color, production_year, seat_count, transmission, fuel_type) VALUES
-(gen_random_uuid(), 1, 3000, 'Hannibal', 'White', 2022, 5, 'AT', '95'),
-(gen_random_uuid(), 2, 2500, 'Nyotie', 'Black', 2016, 4, 'AT', '95'),
-(gen_random_uuid(), 3, 6000, 'Allen', 'Blue', 2020, 5, 'AT', '95'),
-(gen_random_uuid(), 4, 8000, 'Ricky', 'Yellow', 2018, 4, 'MT', '98');
+('bce22263-6461-44de-9fd9-272c906fc15f', 1, 3000, 'Hannibal', 'White', 2022, 5, 'AT', '95'),
+('8f569028-5b4a-45f6-977c-682bbe47aaea', 2, 2500, 'Nyotie', 'Black', 2016, 4, 'AT', '95'),
+('ef9cd5a7-a80e-4a91-9ce7-2d0349da37a7', 3, 6000, 'Allen', 'Blue', 2020, 5, 'AT', '95'),
+('d17eb127-8fee-4ebe-94ea-5c01dde9d26f', 4, 8000, 'Ricky', 'Yellow', 2018, 4, 'MT', '98');


### PR DESCRIPTION
To allow Vehicle entity to use `@Id` annotation, require the field to be db auto-generated value by default